### PR TITLE
less broken docs.rs link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - FMT_VERSION=nightly-2018-07-17
     - CLIPPY_VERSION=nightly-2018-07-17
-    - DOCS_RS_VERSION=nightly-2018-07-07 # https://docs.rs/about
+    - DOCS_RS_VERSION=nightly-2018-07-17 # should be nightly-2018-06-03 https://github.com/onur/docs.rs/blob/32102ce458b34f750ef190182116d9583491a64b/Vagrantfile#L50
 
 matrix:
   include:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://circleci.com/gh/alecmocatta/serde_traitobject/tree/master.svg?style=shield)](https://circleci.com/gh/alecmocatta/serde_traitobject)
 [![Build Status](https://travis-ci.com/alecmocatta/serde_traitobject.svg?branch=master)](https://travis-ci.com/alecmocatta/serde_traitobject)
 
-[Docs](https://docs.rs/serde_traitobject/0.1.0)
+[Docs](https://docs.rs/crate/serde_traitobject)
 
 Serializable trait objects.
 


### PR DESCRIPTION
docs.rs uses nightly-2018-06-03 which balks at trivial_bounds; point to docs.rs page with error rather than 404 as interim