### PR TITLE
Bump serde_closure to fix on latest nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,21 @@ env:
   global:
     - FMT_VERSION=nightly-2018-07-17
     - CLIPPY_VERSION=nightly-2018-07-17
-    - DOCS_RS_VERSION=nightly-2018-07-17 # should be nightly-2018-06-03 https://github.com/onur/docs.rs/blob/32102ce458b34f750ef190182116d9583491a64b/Vagrantfile#L50
+    - DOCS_RS_VERSION=nightly-2018-07-17 # should be 2018-06-03 but failing due to lack of trivial_bounds feature # https://github.com/onur/docs.rs/blob/32102ce458b34f750ef190182116d9583491a64b/Vagrantfile#L50
 
 matrix:
   include:
     - os: linux
       dist: precise
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="precise" # ;-Cpanic=abort;-Clinker=gold
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="precise" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: linux
       dist: trusty
       sudo: false
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: linux
       dist: trusty
       sudo: required # https://docs.travis-ci.com/user/reference/overview/
-      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold
+      env: BUILD="" RUN="x86_64-unknown-linux-gnu i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl" RUSTFLAGS_VARIATIONS=";" DIST="trusty" # ;-Cpanic=abort;-Clinker=gold -Zlinker-flavor=ld;-Clinker=rust-lld -Zlinker-flavor=ld.lld;
     - os: osx
       osx_image: xcode6.4 # https://docs.travis-ci.com/user/reference/osx/
       env: BUILD="x86_64-unknown-linux-musl i686-unknown-linux-musl" RUN="x86_64-apple-darwin i686-apple-darwin" RUSTFLAGS_VARIATIONS=";" # https://github.com/rust-lang/rust/pull/49219 ;-Cpanic=abort
@@ -56,12 +56,12 @@ script: |
     OLD_IFS=$IFS IFS=";"; for RUSTFLAGS in $RUSTFLAGS_VARIATIONS; do ( IFS=$OLD_IFS
       export RUSTFLAGS
       for TARGET in $BUILD $RUN; do (
-        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && exit 0 # RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld" https://github.com/rust-lang/rust/issues/52634
+        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld"
         cargo build --verbose --target "$TARGET" --lib --tests
         cargo build --verbose --target "$TARGET" --lib --tests --release
       ); done
       for TARGET in $RUN; do (
-        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && exit 0 # RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld"
+        [ \( "$TRAVIS_OS_NAME" = "osx" -o \( "$TRAVIS_OS_NAME" = "linux" -a "${DIST-}" = "precise" \) \) -a \( "$TARGET" = "x86_64-unknown-linux-musl" -o "$TARGET" = "i686-unknown-linux-musl" \) ] && RUSTFLAGS="$RUSTFLAGS -C linker=rust-lld -Z linker-flavor=ld.lld"
         RUST_BACKTRACE=full cargo test --target "$TARGET"
         RUST_BACKTRACE=full cargo test --target "$TARGET" --release
       ); done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ metatype = "0.1.1"
 relative = "0.1"
 
 [dev-dependencies]
-serde_closure = "0.1"
+serde_closure = "0.1.2"
 serde_derive = "1.0"
 serde_json = "1.0"
 bincode = "1.0"


### PR DESCRIPTION
Kleene `?` operator in macros was reverted, so serde_closure had to switch back to `*`; also reenable rust-lld test.