### PR TITLE
require 'static to (de)serialize trait object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
 
 env:
   global:
-    - FMT_VERSION=nightly-2018-07-17
-    - CLIPPY_VERSION=nightly-2018-07-17
+    - FMT_VERSION=nightly-2018-07-30
+    - CLIPPY_VERSION=nightly-2018-07-30
     - DOCS_RS_VERSION=nightly-2018-07-17 # should be 2018-06-03 but failing due to lack of trivial_bounds feature # https://github.com/onur/docs.rs/blob/32102ce458b34f750ef190182116d9583491a64b/Vagrantfile#L50
 
 matrix:
@@ -52,7 +52,7 @@ before_script: |
 script: |
   ( set -o errexit;set -o pipefail; set -o xtrace;set -o nounset;
     cargo +$FMT_VERSION fmt -- --check
-    cargo +$CLIPPY_VERSION clippy -- -D warnings
+    cargo +$CLIPPY_VERSION clippy --lib --tests -- -D warnings
     OLD_IFS=$IFS IFS=";"; for RUSTFLAGS in $RUSTFLAGS_VARIATIONS; do ( IFS=$OLD_IFS
       export RUSTFLAGS
       for TARGET in $BUILD $RUN; do (

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ maintenance = { status = "actively-developed" }
 serde = "1.0"
 erased-serde = "0.3"
 metatype = "0.1.1"
-relative = "0.1"
+relative = "0.1.2"
 
 [dev-dependencies]
-serde_closure = "0.1.2"
+serde_closure = "0.1.3"
 serde_derive = "1.0"
 serde_json = "1.0"
 bincode = "1.0"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ println!("{:?}", downcast);
 
 ## Note
 
-This crate works by wrapping the vtable pointer with [relative::Pointer](https://docs.rs/relative) such that it can safely be sent between processes.
+This crate works by wrapping the vtable pointer with [relative::Vtable](https://docs.rs/relative) such that it can safely be sent between processes.
 
 This currently requires Rust nightly.
 

--- a/src/convenience.rs
+++ b/src/convenience.rs
@@ -108,7 +108,7 @@ impl<'a, A, R> ops::FnOnce<A> for Box<dyn FnBox<A, Output = R> + Send + 'a> {
 		self.0.call_box(args)
 	}
 }
-impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Box<T> {
+impl<T: Serialize + Deserialize + ?Sized + 'static> serde::ser::Serialize for Box<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -116,7 +116,7 @@ impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Box<T> {
 		serialize(&self.0, serializer)
 	}
 }
-impl<'de, T: Serialize + Deserialize + ?Sized> serde::de::Deserialize<'de> for Box<T> {
+impl<'de, T: Serialize + Deserialize + ?Sized + 'static> serde::de::Deserialize<'de> for Box<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -200,7 +200,7 @@ impl<T: Serialize + Deserialize + fmt::Display + ?Sized> fmt::Display for Rc<T> 
 		self.0.fmt(f)
 	}
 }
-impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Rc<T> {
+impl<T: Serialize + Deserialize + ?Sized + 'static> serde::ser::Serialize for Rc<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -208,7 +208,7 @@ impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Rc<T> {
 		serialize(&self.0, serializer)
 	}
 }
-impl<'de, T: Serialize + Deserialize + ?Sized> serde::de::Deserialize<'de> for Rc<T> {
+impl<'de, T: Serialize + Deserialize + ?Sized + 'static> serde::de::Deserialize<'de> for Rc<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -292,7 +292,7 @@ impl<T: Serialize + Deserialize + fmt::Display + ?Sized> fmt::Display for Arc<T>
 		self.0.fmt(f)
 	}
 }
-impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Arc<T> {
+impl<T: Serialize + Deserialize + ?Sized + 'static> serde::ser::Serialize for Arc<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -300,7 +300,7 @@ impl<T: Serialize + Deserialize + ?Sized> serde::ser::Serialize for Arc<T> {
 		serialize(&self.0, serializer)
 	}
 }
-impl<'de, T: Serialize + Deserialize + ?Sized> serde::de::Deserialize<'de> for Arc<T> {
+impl<'de, T: Serialize + Deserialize + ?Sized + 'static> serde::de::Deserialize<'de> for Arc<T> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -84,16 +84,16 @@ fn main() {
 		assert_eq!(g(22), "hey 123!");
 		assert_eq!(
 			***Box::<any::Any>::downcast::<serde_traitobject::Box<usize>>(h.into_any()).unwrap(),
-			987654321
+			987_654_321
 		);
 		assert_eq!(
 			*Box::<any::Any>::downcast::<usize>(
 				Box::<any::Any>::downcast::<serde_traitobject::Box<serde_traitobject::Any>>(
 					i.into_any()
 				).unwrap()
-					.into_any()
+				.into_any()
 			).unwrap(),
-			987654321
+			987_654_321
 		);
 		assert_eq!(**j, "abc");
 		assert_eq!(*k, "def");
@@ -109,9 +109,9 @@ fn main() {
 		let a: Box<any::Any> = *a;
 		let _: Box<usize> = Box::<any::Any>::downcast(a).unwrap();
 
-		let a: serde_traitobject::Box<serde_traitobject::Any> = serde_traitobject::Box::new(
-			serde_traitobject::Box::new(1usize) as serde_traitobject::Box<serde_traitobject::Any>,
-		);
+		let a: serde_traitobject::Box<serde_traitobject::Any> =
+			serde_traitobject::Box::new(serde_traitobject::Box::new(1usize)
+				as serde_traitobject::Box<serde_traitobject::Any>);
 		let a: Box<any::Any> = a.into_any();
 		let a: Box<serde_traitobject::Box<serde_traitobject::Any>> =
 			Box::<any::Any>::downcast(a).unwrap();
@@ -127,8 +127,8 @@ fn main() {
 			e: Box::new(78u8),
 			f: serde_traitobject::Box::new(78u8),
 			g: serde_traitobject::Box::new(Fn!(|a: usize| format!("hey {}!", a + 101))),
-			h: serde_traitobject::Box::new(serde_traitobject::Box::new(987654321usize)),
-			i: serde_traitobject::Box::new(serde_traitobject::Box::new(987654321usize)
+			h: serde_traitobject::Box::new(serde_traitobject::Box::new(987_654_321usize)),
+			i: serde_traitobject::Box::new(serde_traitobject::Box::new(987_654_321usize)
 				as serde_traitobject::Box<serde_traitobject::Any>),
 			j: serde_traitobject::Box::new(String::from("abc")),
 			k: Box::new(String::from("def")),
@@ -170,8 +170,8 @@ fn main() {
 		e: Box::new(78u8),
 		f: serde_traitobject::Box::new(78u8),
 		g: serde_traitobject::Box::new(Fn!(|a: usize| format!("hey {}!", a + 101))),
-		h: serde_traitobject::Box::new(serde_traitobject::Box::new(987654321usize)),
-		i: serde_traitobject::Box::new(serde_traitobject::Box::new(987654321usize)
+		h: serde_traitobject::Box::new(serde_traitobject::Box::new(987_654_321usize)),
+		i: serde_traitobject::Box::new(serde_traitobject::Box::new(987_654_321usize)
 			as serde_traitobject::Box<serde_traitobject::Any>),
 		j: serde_traitobject::Box::new(String::from("abc")),
 		k: Box::new(String::from("def")),
@@ -202,8 +202,7 @@ fn main() {
 				"SERDE_TRAITOBJECT_SPAWNED",
 				serde_json::to_string(&(&original, bincode::serialize(&original).unwrap()))
 					.unwrap(),
-			)
-			.output()
+			).output()
 			.unwrap();
 		if !output.status.success() {
 			panic!("{}: {:?}", i, output);


### PR DESCRIPTION
which lets us rely on relative's use of intrinsics::type_id rather than our hacky one; bump relative