### PR TITLE
remove FnBox since it's deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ There are two ways to (de)serialize your trait object:
 
 Additionally, there are several convenience traits implemented that extend their stdlib counterparts:
 
- * [Any](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Fn.html), [FnBox](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.FnBox.html), [FnMut](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.FnOnce.html)
+ * [Any](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.Fn.html), [FnMut](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.1.3/serde_traitobject/trait.FnOnce.html)
 
 These are automatically implemented on all implementors of their stdlib counterparts that also implement `serde::Serialize` and `serde::de::DeserializeOwned`.
 

--- a/src/convenience.rs
+++ b/src/convenience.rs
@@ -115,18 +115,6 @@ impl<T: Serialize + Deserialize + fmt::Display + ?Sized> fmt::Display for Box<T>
 		self.0.fmt(f)
 	}
 }
-impl<'a, A, R> ops::FnOnce<A> for Box<dyn FnBox<A, Output = R> + 'a> {
-	type Output = R;
-	extern "rust-call" fn call_once(self, args: A) -> R {
-		self.0.call_box(args)
-	}
-}
-impl<'a, A, R> ops::FnOnce<A> for Box<dyn FnBox<A, Output = R> + Send + 'a> {
-	type Output = R;
-	extern "rust-call" fn call_once(self, args: A) -> R {
-		self.0.call_box(args)
-	}
-}
 impl<T: Serialize + Deserialize + ?Sized + 'static> serde::ser::Serialize for Box<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
@@ -493,12 +481,6 @@ impl<T: ?Sized> Debug for T where T: fmt::Debug + Serialize + Deserialize {}
 /// It can be made into a trait object which is then (de)serializable.
 pub trait FnOnce<Args>: ops::FnOnce<Args> + Serialize + Deserialize {}
 impl<T: ?Sized, Args> FnOnce<Args> for T where T: ops::FnOnce<Args> + Serialize + Deserialize {}
-
-/// A convenience trait implemented on all (de)serializable implementors of [std::boxed::FnBox].
-///
-/// It can be made into a trait object which is then (de)serializable.
-pub trait FnBox<Args>: boxed::FnBox<Args> + Serialize + Deserialize {}
-impl<T: ?Sized, Args> FnBox<Args> for T where T: boxed::FnBox<Args> + Serialize + Deserialize {}
 
 /// A convenience trait implemented on all (de)serializable implementors of [std::ops::FnMut].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! Additionally, there are several convenience traits implemented that extend their stdlib counterparts:
 //!
-//!  * [Any], [Debug], [Display], [Error], [Fn], [FnBox], [FnMut], [FnOnce]
+//!  * [Any], [Debug], [Display], [Error], [Fn], [FnMut], [FnOnce]
 //!
 //! These are automatically implemented on all implementors of their stdlib counterparts that also implement `serde::Serialize` and `serde::de::DeserializeOwned`.
 //!
@@ -107,7 +107,6 @@
 	unsize,
 	specialization,
 	trivial_bounds,
-	fnbox
 )]
 #![warn(
 	missing_copy_implementations,


### PR DESCRIPTION
FnBox is deprecated since 1.35([#28796](https://github.com/rust-lang/rust/issues/28796))

Just removed FnBox instances. 