### PR TITLE
Use pointer rather than reference to adhere to unsafe guidelines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_traitobject"
-version = "0.1.7"
+version = "0.1.8"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -12,7 +12,7 @@ This library enables the serialization and deserialization of trait objects such
 """
 repository = "https://github.com/alecmocatta/serde_traitobject"
 homepage = "https://github.com/alecmocatta/serde_traitobject"
-documentation = "https://docs.rs/serde_traitobject/0.1.7"
+documentation = "https://docs.rs/serde_traitobject/0.1.8"
 readme = "README.md"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_traitobject.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_traitobject/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_traitobject/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/)
+[Docs](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/)
 
 **Serializable and deserializable trait objects.**
 
@@ -12,7 +12,7 @@ This library enables the serialization and deserialization of trait objects so t
 
 For example, if you have multiple forks of a process, or the same binary running on each of a cluster of machines, this library lets you send trait objects between them.
 
-Any trait can be made (de)serializable when made into a trait object by adding this crate's [Serialize](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Serialize.html) and [Deserialize](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Deserialize.html) traits as supertraits:
+Any trait can be made (de)serializable when made into a trait object by adding this crate's [Serialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Serialize.html) and [Deserialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Deserialize.html) traits as supertraits:
 
 ```rust
 trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
@@ -28,12 +28,12 @@ struct Message(#[serde(with = "serde_traitobject")] Box<dyn MyTrait>);
 And that's it! The two traits are automatically implemented for all `T: serde::Serialize` and all `T: serde::de::DeserializeOwned`, so as long as all implementors of your trait are themselves serializable then you're good to go.
 
 There are two ways to (de)serialize your trait object:
- * Apply the `#[serde(with = "serde_traitobject")]` [field attribute](https://serde.rs/attributes.html), which instructs serde to use this crate's [serialize](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/fn.serialize.html) and [deserialize](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/fn.deserialize.html) functions;
- * The [Box](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/struct.Box.html), [Rc](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/struct.Rc.html) and [Arc](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/struct.Arc.html) structs, which are simple wrappers around their stdlib counterparts that automatically handle (de)serialization without needing the above annotation;
+ * Apply the `#[serde(with = "serde_traitobject")]` [field attribute](https://serde.rs/attributes.html), which instructs serde to use this crate's [serialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/fn.serialize.html) and [deserialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/fn.deserialize.html) functions;
+ * The [Box](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Box.html), [Rc](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Rc.html) and [Arc](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Arc.html) structs, which are simple wrappers around their stdlib counterparts that automatically handle (de)serialization without needing the above annotation;
 
 Additionally, there are several convenience traits implemented that extend their stdlib counterparts:
 
- * [Any](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.Fn.html), [FnMut](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.1.7/serde_traitobject/trait.FnOnce.html)
+ * [Any](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Fn.html), [FnMut](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.FnOnce.html)
 
 These are automatically implemented on all implementors of their stdlib counterparts that also implement `serde::Serialize` and `serde::de::DeserializeOwned`.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-08-15
+      rust_lint_toolchain: nightly-2019-10-15
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //!
 //! ```
 //! # use serde_derive::{Serialize, Deserialize};
-//! # fn main() {
 //! trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 //! 	fn my_method(&self);
 //! }
@@ -19,7 +18,6 @@
 //! struct Message(#[serde(with = "serde_traitobject")] Box<dyn MyTrait>);
 //!
 //! // Woohoo, `Message` is now serializable!
-//! # }
 //! ```
 //!
 //! And that's it! The two traits are automatically implemented for all `T: serde::Serialize` and all `T: serde::de::DeserializeOwned`, so as long as all implementors of your trait are themselves serializable then you're good to go.
@@ -36,7 +34,6 @@
 //!
 //! ```
 //! # use serde_derive::{Serialize, Deserialize};
-//! # fn main() {
 //! use std::any::Any;
 //! use serde_traitobject as s;
 //!
@@ -61,7 +58,6 @@
 //! println!("{:?}", downcast);
 //! # assert_eq!(format!("{:?}", downcast), "MyStruct { foo: \"abc\", bar: 123 }");
 //! // MyStruct { foo: "abc", bar: 123 }
-//! # }
 //! ```
 //!
 //! # Security
@@ -139,18 +135,15 @@ pub use convenience::*;
 /// ```
 /// use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// 	fn my_method(&self);
 /// }
-/// # }
 /// ```
 ///
 /// Now your trait object is serializable!
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 /// #
-/// # fn main() {
 /// # trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// # 	fn my_method(&self);
 /// # }
@@ -158,13 +151,11 @@ pub use convenience::*;
 /// struct Message(#[serde(with = "serde_traitobject")] Box<dyn MyTrait>);
 ///
 /// // Woohoo, `Message` is now serializable!
-/// # }
 /// ```
 ///
 /// Any implementers of `MyTrait` would now have to themselves implement `serde::Serialize` and `serde::de::DeserializeOwned`. This would typically be through `serde_derive`, like:
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
-/// # fn main() {
 /// # trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// # 	fn my_method(&self);
 /// # }
@@ -180,7 +171,6 @@ pub use convenience::*;
 /// 		println!("foo: {}", self.foo);
 /// 	}
 /// }
-/// # }
 /// ```
 pub trait Serialize: serialize::Sealed {}
 impl<T: serde::ser::Serialize + ?Sized> Serialize for T {}
@@ -193,18 +183,15 @@ impl<T: serde::ser::Serialize + ?Sized> Serialize for T {}
 /// ```
 /// use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// 	fn my_method(&self);
 /// }
-/// # }
 /// ```
 ///
 /// Now your trait object is serializable!
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 /// #
-/// # fn main() {
 /// # trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// # 	fn my_method(&self);
 /// # }
@@ -212,13 +199,11 @@ impl<T: serde::ser::Serialize + ?Sized> Serialize for T {}
 /// struct Message(#[serde(with = "serde_traitobject")] Box<dyn MyTrait>);
 ///
 /// // Woohoo, `Message` is now serializable!
-/// # }
 /// ```
 ///
 /// Any implementers of `MyTrait` would now have to themselves implement `serde::Serialize` and `serde::de::DeserializeOwned`. This would typically be through `serde_derive`, like:
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
-/// # fn main() {
 /// # trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
 /// # 	fn my_method(&self);
 /// # }
@@ -234,7 +219,6 @@ impl<T: serde::ser::Serialize + ?Sized> Serialize for T {}
 /// 		println!("foo: {}", self.foo);
 /// 	}
 /// }
-/// # }
 /// ```
 pub trait Deserialize: deserialize::Sealed {}
 impl<T: serde::de::DeserializeOwned> Deserialize for T {}
@@ -497,26 +481,22 @@ impl<'de, T: Deserialize + ?Sized> serde::de::DeserializeSeed<'de> for Deseriali
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// #[derive(Serialize, Deserialize)]
 /// struct MyStruct {
 /// 	#[serde(with = "serde_traitobject")]
 /// 	field: Box<dyn serde_traitobject::Any>,
 /// }
-/// # }
 /// ```
 ///
 /// Or, alternatively, if only Serialize is desired:
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// #[derive(Serialize)]
 /// struct MyStruct {
 /// 	#[serde(serialize_with = "serde_traitobject::serialize")]
 /// 	field: Box<dyn serde_traitobject::Any>,
 /// }
-/// # }
 /// ```
 pub fn serialize<T: Serialize + ?Sized + 'static, B: AsRef<T> + ?Sized, S>(
 	t: &B, serializer: S,
@@ -533,26 +513,22 @@ where
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// #[derive(Serialize, Deserialize)]
 /// struct MyStruct {
 /// 	#[serde(with = "serde_traitobject")]
 /// 	field: Box<dyn serde_traitobject::Any>,
 /// }
-/// # }
 /// ```
 ///
 /// Or, alternatively, if only Deserialize is desired:
 /// ```
 /// # use serde_derive::{Serialize, Deserialize};
 ///
-/// # fn main() {
 /// #[derive(Deserialize)]
 /// struct MyStruct {
 /// 	#[serde(deserialize_with = "serde_traitobject::deserialize")]
 /// 	field: Box<dyn serde_traitobject::Any>,
 /// }
-/// # }
 /// ```
 pub fn deserialize<'de, T: Deserialize + ?Sized + 'static, B, D>(
 	deserializer: D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //!
 //! This crate currently requires Rust nightly.
 
-#![doc(html_root_url = "https://docs.rs/serde_traitobject/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/serde_traitobject/0.1.8")]
 #![feature(
 	arbitrary_self_types,
 	coerce_unsized,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -66,6 +66,7 @@ impl Hello for u8 {
 	}
 }
 
+#[allow(clippy::too_many_lines)]
 fn main() {
 	let test = |Abc {
 	                a,


### PR DESCRIPTION
Note: switch to `&raw mut _` when it lands https://github.com/rust-lang/rust/issues/64490