### PR TITLE
Update to metatype v0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_traitobject"
-version = "0.1.8"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","encoding","rust-patterns","network-programming"]
@@ -12,7 +12,7 @@ This library enables the serialization and deserialization of trait objects such
 """
 repository = "https://github.com/alecmocatta/serde_traitobject"
 homepage = "https://github.com/alecmocatta/serde_traitobject"
-documentation = "https://docs.rs/serde_traitobject/0.1.8"
+documentation = "https://docs.rs/serde_traitobject/0.2.0"
 readme = "README.md"
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 serde = "1.0"
 erased-serde = "0.3"
-metatype = "0.1.1"
+metatype = "0.2"
 relative = "0.1.2"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![MIT / Apache 2.0 licensed](https://img.shields.io/crates/l/serde_traitobject.svg?maxAge=2592000)](#License)
 [![Build Status](https://dev.azure.com/alecmocatta/serde_traitobject/_apis/build/status/tests?branchName=master)](https://dev.azure.com/alecmocatta/serde_traitobject/_build/latest?branchName=master)
 
-[Docs](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/)
+[Docs](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/)
 
 **Serializable and deserializable trait objects.**
 
@@ -12,7 +12,7 @@ This library enables the serialization and deserialization of trait objects so t
 
 For example, if you have multiple forks of a process, or the same binary running on each of a cluster of machines, this library lets you send trait objects between them.
 
-Any trait can be made (de)serializable when made into a trait object by adding this crate's [Serialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Serialize.html) and [Deserialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Deserialize.html) traits as supertraits:
+Any trait can be made (de)serializable when made into a trait object by adding this crate's [Serialize](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Serialize.html) and [Deserialize](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Deserialize.html) traits as supertraits:
 
 ```rust
 trait MyTrait: serde_traitobject::Serialize + serde_traitobject::Deserialize {
@@ -28,12 +28,12 @@ struct Message(#[serde(with = "serde_traitobject")] Box<dyn MyTrait>);
 And that's it! The two traits are automatically implemented for all `T: serde::Serialize` and all `T: serde::de::DeserializeOwned`, so as long as all implementors of your trait are themselves serializable then you're good to go.
 
 There are two ways to (de)serialize your trait object:
- * Apply the `#[serde(with = "serde_traitobject")]` [field attribute](https://serde.rs/attributes.html), which instructs serde to use this crate's [serialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/fn.serialize.html) and [deserialize](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/fn.deserialize.html) functions;
- * The [Box](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Box.html), [Rc](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Rc.html) and [Arc](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/struct.Arc.html) structs, which are simple wrappers around their stdlib counterparts that automatically handle (de)serialization without needing the above annotation;
+ * Apply the `#[serde(with = "serde_traitobject")]` [field attribute](https://serde.rs/attributes.html), which instructs serde to use this crate's [serialize](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/fn.serialize.html) and [deserialize](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/fn.deserialize.html) functions;
+ * The [Box](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/struct.Box.html), [Rc](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/struct.Rc.html) and [Arc](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/struct.Arc.html) structs, which are simple wrappers around their stdlib counterparts that automatically handle (de)serialization without needing the above annotation;
 
 Additionally, there are several convenience traits implemented that extend their stdlib counterparts:
 
- * [Any](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.Fn.html), [FnMut](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.1.8/serde_traitobject/trait.FnOnce.html)
+ * [Any](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Any.html), [Debug](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Debug.html), [Display](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Display.html), [Error](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Error.html), [Fn](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.Fn.html), [FnMut](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.FnMut.html), [FnOnce](https://docs.rs/serde_traitobject/0.2.0/serde_traitobject/trait.FnOnce.html)
 
 These are automatically implemented on all implementors of their stdlib counterparts that also implement `serde::Serialize` and `serde::de::DeserializeOwned`.
 
@@ -79,7 +79,7 @@ Three things are serialized alongside the vtable pointer for the purpose of vali
 
 At some point in Rust's future, I think it would be great if the latter could be used to safely look up and create a trait object. As it is, that functionality doesn't exist yet, so what this crate does instead is serialize the vtable pointer (relative to a static base), and do as much validity checking as it reasonably can before it can be used and potentially invoke UB.
 
-The first two are [checked for validity](https://github.com/alecmocatta/relative/blob/dae206663a09b9c0c4b3012c528b0e9c063df742/src/lib.rs#L457-L474) before usage of the vtable pointer. The `build_id` ensures that the vtable pointer came from an invocation of an identically laid out binary<sup>1</sup>. The `type_id` ensures that the trait object being deserialized is the same type as the trait object that was serialized. They ensure that under non-malicious conditions, attempts to deserialize invalid data return an error rather than UB. The `type_id` of the concrete type is used as a [sanity check](https://github.com/alecmocatta/serde_traitobject/blob/50918f588ac7b1efc113de55bdf70bdae3d50554/src/lib.rs#L464) that panics if it differs from the `type_id` of the concrete type to be deserialized.
+The first two are [checked for validity](https://github.com/alecmocatta/relative/blob/dae206663a09b9c0c4b3012c528b0e9c063df742/src/lib.rs#L457-L474) before usage of the vtable pointer. The `build_id` ensures that the vtable pointer came from an invocation of an identically laid out binary<sup>1</sup>. The `type_id` ensures that the trait object being deserialized is the same type as the trait object that was serialized. They ensure that under non-malicious conditions, attempts to deserialize invalid data return an error rather than UB. The `type_id` of the concrete type is used as a [sanity check](https://github.com/alecmocatta/serde_traitobject/blob/b20d74e183063e7d49aff2eabc9dcd5bc26d7c07/src/lib.rs#L469) that panics if it differs from the `type_id` of the concrete type to be deserialized.
 
 Regarding collisions, the 128 bit `build_id` colliding is sufficiently unlikely that it can be relied upon to never occur. The 64 bit `type_id` colliding is possible, see [rust-lang/rust#10389](https://github.com/rust-lang/rust/issues/10389), though exceedingly unlikely to occur in practise.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     endpoint: alecmocatta
     default:
       rust_toolchain: nightly
-      rust_lint_toolchain: nightly-2019-10-15
+      rust_lint_toolchain: nightly-2019-10-17
       rust_flags: ''
       rust_features: ''
       rust_target_check: ''

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@
 	unused_results,
 	clippy::pedantic
 )] // from https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
-#![allow(where_clauses_object_safety)]
+#![allow(where_clauses_object_safety, clippy::must_use_candidate)]
 
 mod convenience;
 
@@ -299,7 +299,7 @@ mod deserialize {
 		fn deserialize_erased(
 			self: *const Self, deserializer: &mut dyn erased_serde::Deserializer,
 		) -> Result<NonNull<()>, erased_serde::Error> {
-			erased_serde::deserialize::<T>(deserializer)
+			erased_serde::deserialize::<Self>(deserializer)
 				.map(|x| NonNull::new(boxed::Box::into_raw(boxed::Box::new(x)).cast()).unwrap())
 		}
 
@@ -319,8 +319,9 @@ mod deserialize {
 	/// Rust currently doesn't support returning Self traitobjects from
 	/// traitobject methods. Work around that by returning a thin pointer and
 	/// fattening it.
+	#[allow(clippy::module_name_repetitions)]
 	#[inline]
-	pub fn deserialize_erased<'de, T: ?Sized>(
+	pub fn deserialize_erased<T: ?Sized>(
 		self_: *const T, deserializer: &mut dyn erased_serde::Deserializer,
 	) -> Result<boxed::Box<T>, erased_serde::Error>
 	where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! At some point in Rust's future, I think it would be great if the latter could be used to safely look up and create a trait object. As it is, that functionality doesn't exist yet, so what this crate does instead is serialize the vtable pointer (relative to a static base), and do as much validity checking as it reasonably can before it can be used and potentially invoke UB.
 //!
-//! The first two are [checked for validity](https://github.com/alecmocatta/relative/blob/dae206663a09b9c0c4b3012c528b0e9c063df742/src/lib.rs#L457-L474) before usage of the vtable pointer. The `build_id` ensures that the vtable pointer came from an invocation of an identically laid out binary<sup>1</sup>. The `type_id` ensures that the trait object being deserialized is the same type as the trait object that was serialized. They ensure that under non-malicious conditions, attempts to deserialize invalid data return an error rather than UB. The `type_id` of the concrete type is used as a [sanity check](https://github.com/alecmocatta/serde_traitobject/blob/50918f588ac7b1efc113de55bdf70bdae3d50554/src/lib.rs#L464) that panics if it differs from the `type_id` of the concrete type to be deserialized.
+//! The first two are [checked for validity](https://github.com/alecmocatta/relative/blob/dae206663a09b9c0c4b3012c528b0e9c063df742/src/lib.rs#L457-L474) before usage of the vtable pointer. The `build_id` ensures that the vtable pointer came from an invocation of an identically laid out binary<sup>1</sup>. The `type_id` ensures that the trait object being deserialized is the same type as the trait object that was serialized. They ensure that under non-malicious conditions, attempts to deserialize invalid data return an error rather than UB. The `type_id` of the concrete type is used as a [sanity check](https://github.com/alecmocatta/serde_traitobject/blob/b20d74e183063e7d49aff2eabc9dcd5bc26d7c07/src/lib.rs#L469) that panics if it differs from the `type_id` of the concrete type to be deserialized.
 //!
 //! Regarding collisions, the 128 bit `build_id` colliding is sufficiently unlikely that it can be relied upon to never occur. The 64 bit `type_id` colliding is possible, see [rust-lang/rust#10389](https://github.com/rust-lang/rust/issues/10389), though exceedingly unlikely to occur in practise.
 //!
@@ -94,7 +94,7 @@
 //!
 //! This crate currently requires Rust nightly.
 
-#![doc(html_root_url = "https://docs.rs/serde_traitobject/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/serde_traitobject/0.2.0")]
 #![feature(
 	arbitrary_self_types,
 	coerce_unsized,


### PR DESCRIPTION
Also:
* Use fat pointers and `arbitrary_self_types` rather than fat references
* And avoid creating an uninitialized box
* Bump version to v0.2.0